### PR TITLE
Added functionality for running on Windows, testing metadata and allowing new command line arguments

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,21 @@ fields that are defined must be equal to the fields in the output document.
 The output document may include other fields. To test that an output field
 doesn't exist, use `"field": null`.
 
+## Command line arguments
+
+| Argument | Description | Default |
+| -------- | ----------- | ------- |
+| `--filters` | File with Logstash filter definition to test. | `filter.conf` |
+| `--testcases` | File with test cases. | `testcases.js` |
+| `--remove_tempdir` | Whether to remove the temp dir that is created during execution (yes/no). | `yes` (any other value will be equivalent to `no`) |
+| `--logstash` | Path to the Logstash executable. | \[ `/opt/logstash/bin/logstash`, `/usr/share/logstash/bin/logstash` \] |
+
+Example on Windows:
+
+```
+logstash_filter_test.py --remove_tempdir=yes --logstash C:\path\to\logstash-6.2.3\bin\logstash.bat --filters C:\path\to\logstash\indexer\config\filter.conf --testcases C:\path\to\logstash\indexer\test\testcases.js
+```
+
 ## Testing from Python
 
 If you don't like the testcase file format, it's easy to test by yourself:

--- a/logstash_filter_test.py
+++ b/logstash_filter_test.py
@@ -5,6 +5,7 @@ import sys
 import json
 
 from logstash_filter_run import logstash_filter_run
+from logstash_filter_run import LOGSTASH_BIN_ALTERNATIVES
 
 
 # This is copied from https://github.com/linjackson78/jstyleson
@@ -110,7 +111,6 @@ def _remove_last_comma(str_list, before_index):
     if str_list[i] == ',':
         str_list[i] = ''
 
-
 def print_results(testcases, outputs):
     expecteds = [expected for _inp, expected in testcases]
     n_errs = 0
@@ -138,11 +138,11 @@ def print_results(testcases, outputs):
     return n_errs
 
 
-def logstash_filter_test(filter_fn='filter.conf', testcases_fn='testcases.js'):
+def logstash_filter_test(filter_fn='filter.conf', testcases_fn='testcases.js', logstash_bin_fn=None, remove_tempdir="yes"):
     testcases = json.loads(dispose(open(testcases_fn).read()))
     inputs = [inp for inp, _expected in testcases]
     filter_def = open(filter_fn).read()
-    outputs = logstash_filter_run(inputs, filter_def)
+    outputs = logstash_filter_run(inputs, filter_def, logstash_bin_fn, remove_tempdir == "yes")
     n_errs = print_results(testcases, outputs)
     return outputs, n_errs
 
@@ -154,9 +154,14 @@ def main():
                         help="File with logstash filter definition to test. default: filter.conf")
     parser.add_argument("--testcases", default="testcases.js",
                         help="File with testcases. default: testcases.js")
+    parser.add_argument("--logstash", default=None,
+                        help="Path to Logstash executable. default: " + ",".join(LOGSTASH_BIN_ALTERNATIVES))
+    parser.add_argument("--remove_tempdir", default="yes",
+                        help="Whether to remove the temp dir (yes/no). default: yes")
+
     args = parser.parse_args()
 
-    _outputs, n_errs = logstash_filter_test(args.filters, args.testcases)
+    _outputs, n_errs = logstash_filter_test(args.filters, args.testcases, args.logstash, args.remove_tempdir)
 
     return 0 if n_errs == 0 else 1
 


### PR DESCRIPTION
Hi!

What do you think about these enhancements?

I found your Python script incredibly useful. I was relieved to find it after getting frustrated with not being able to run logstash-filter-verifier on Windows. Since Python is a lot more accessible to me than Golang I then also made a few more changes, in particular being able to test metadata.

There are also a few other ideas that I have and would like to implement, like being able to use regexes in addition to literal string comparisons in the test case definitions. Would be great to hear your feedback on this.

Dom